### PR TITLE
feat: front header nav link 수정, login input onchange avoid

### DIFF
--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -13,18 +13,18 @@ const App = () => {
   return (
     <>
 	<RecoilRoot>
-    <Header/>
 		<BrowserRouter>
+				<Header/>
 			<Routes>
-			<Route path="/" element={<Main/>}/>
-			<Route path="/board" element={<Board/>}/>
-			<Route path="/UserPage" element={<UserPage/>}/>
-			<Route path='/LoginPage' element={<LoginPage/>}/>
-			<Route path="/RegisterPage" element={<RegisterPage/>}/>
+				<Route path="/" element={<Main/>}/>
+				<Route path="/board" element={<Board/>}/>
+				<Route path="/UserPage" element={<UserPage/>}/>
+				<Route path='/LoginPage' element={<LoginPage/>}/>
+				<Route path="/RegisterPage" element={<RegisterPage/>}/>
 			</Routes>
 		</BrowserRouter>
 	</RecoilRoot>
-      <Footer/>
+	<Footer/>
     </>
   )
 }

--- a/frontend-react/src/Atoms/Login.ts
+++ b/frontend-react/src/Atoms/Login.ts
@@ -9,7 +9,7 @@ export interface ILogin {
 };
 
 
-export const isLoginState = atom<boolean>({
+export const isLoginState = atom({
   key: 'isLogin',
   default: false,
   effects_UNSTABLE: [persistAtom],

--- a/frontend-react/src/Layout/Header.tsx
+++ b/frontend-react/src/Layout/Header.tsx
@@ -3,19 +3,20 @@ import Button from 'react-bootstrap/Button';
 import Container from 'react-bootstrap/Container';
 import Form from 'react-bootstrap/Form';
 import Nav from 'react-bootstrap/Nav';
-import Navbar from 'react-bootstrap/Navbar';
+import Navbar  from 'react-bootstrap/Navbar';
 import 'bootstrap/dist/css/bootstrap.css';
 import { isLoginState } from '../Atoms/Login';
 import { useRecoilState } from 'recoil';
+import { Link, useNavigate } from 'react-router-dom';
 
 const Header = () => {
   const [loggedIn, setLoggedIn] = useRecoilState(isLoginState);
 
+  const navigate = useNavigate();
   const handleLogout = () => {
     setLoggedIn(false);
+	navigate('/');
   };
-
-  console.log(loggedIn);
 
   return (
     <Navbar expand="lg" className="bg-body-tertiary">
@@ -24,8 +25,8 @@ const Header = () => {
         <Navbar.Toggle aria-controls="responsive-navbar-nav" />
         <Navbar.Collapse id="responsive-navbar-nav">
           <Nav className="me-auto">
-            <Nav.Link href="/">메인 페이지</Nav.Link>
-            <Nav.Link href="/Board">강의평가</Nav.Link>
+            <Nav.Link as={ Link } to="/"> 메인 페이지 </Nav.Link>
+            <Nav.Link as={ Link } to="/Board"> 강의평가 </Nav.Link>
           </Nav>
           <Nav className="ms-auto">
             <Form className="d-flex">
@@ -41,19 +42,19 @@ const Header = () => {
             </Form>
             {loggedIn ? (
               <>
-                <Button variant="light" size="sm" href="/UserPage">
+                <Button variant="light" size="sm" onClick={() => navigate("/UserPage")}>
                   마이페이지
                 </Button>
-                <Button variant="light" size="sm" onClick={handleLogout} href="/">
+                <Button variant="light" size="sm" onClick={handleLogout}>
                   로그아웃
                 </Button>
               </>
             ) : (
 				<>
-				<Button variant="light" size="sm" href="/RegisterPage">
+				<Button variant="light" size="sm" onClick={() => navigate("/RegisterPage")}>
 					회원가입
 				</Button>
-				<Button variant="light" size="sm" href="/LoginPage">
+				<Button variant="light" size="sm" onClick={() => navigate("/LoginPage")}>
 					로그인
 				</Button>
 			  </>

--- a/frontend-react/src/Pages/Auth/LoginPage.tsx
+++ b/frontend-react/src/Pages/Auth/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { memo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { LoginState, isLoginState } from "../../Atoms/Login";
 import { useRecoilState } from "recoil";
@@ -5,28 +6,33 @@ import { fetchLogin } from "../../Api/api";
 import { useMutation } from "react-query";
 import { useState } from "react";
 
-
 const LoginPage = () => {
-	const [id, setId] = useState("");
-	const [password, setPassword] = useState("");
+	const navigate = useNavigate();
+
+	const id = useRef("");
+	const password = useRef("");
 	const [, setLoginState] = useRecoilState(LoginState);
 	const [, setIsLoginState] = useRecoilState(isLoginState);
- 	const navigate = useNavigate();
 
-	const loginMutation = useMutation(() => fetchLogin(id, password), {
+	const loginMutation = useMutation(() => fetchLogin(id.current, password.current), {
 		 onSuccess: () => {
-			setLoginState({ id: id, password: password });
+			setLoginState({ id: id.current, password: password.current });
 			setIsLoginState(true);
 			navigate('/');
 		},
 		onError: () => {
 			alert("로그인에 실패했습니다.");
 			setIsLoginState(false);
-			setId('');
-			setPassword('');
+			id.current = "";
+			password.current = "";
 		}
 	});
 	
+	const handleChange = (e: any, ref: any) => {
+		const value = e.target.value;
+		ref.current = value;
+	}
+
 	const onSubmit = (e: any) => {
 		e.preventDefault();
 		// 전처리
@@ -46,18 +52,14 @@ const LoginPage = () => {
 					<form onSubmit={onSubmit} className="space-y-4 md:space-y-6">
 						<h2 className="text-center text-slate-500">Login</h2>
 						<input type='text' 
-								id='id'
-								value={id} 
-								onChange={ (e) => setId(e.target.value) } 
+								onChange={(e) => handleChange(e, id)}
 								className="bg-gray-50 border border-gray-300 text-gray-900
 											sm:text-sm rounded-lg focus:ring-primary-600 
 											focus:border-primary-600 block w-full p-2.5"
 											placeholder="id"
 						/>
 						<input type='password'
-								id='password'
-								value={password}
-								onChange={ (e) => setPassword(e.target.value) }
+							   onChange={(e) => handleChange(e, password)}
 								className="bg-gray-50 border border-gray-300 text-gray-900
 								sm:text-sm rounded-lg focus:ring-primary-600 
 								focus:border-primary-600 block w-full p-2.5"
@@ -84,4 +86,4 @@ const LoginPage = () => {
     );
 };
 
-export default LoginPage;
+export default memo(LoginPage);

--- a/frontend-react/src/Pages/Main/Main.tsx
+++ b/frontend-react/src/Pages/Main/Main.tsx
@@ -9,7 +9,6 @@ const Main = () => {
 	const [ lectureList, setLectureList ] = useRecoilState(lectureListState);
 	const { isLoading, isError, data } = useQuery(['lecture'], fetchPost, {
 			onSuccess: (data) => setLectureList(data),
-			onError: (error) => console.log(error),
 			//기본 캐시 타임 == 5min
 		});
 		if (isLoading)


### PR DESCRIPTION
1. 기존 헤더에 href로 라우터 이동시 reload되는 이슈 발생 => recoil 로 저장한 atom들 초기화됨
Nav.Link를 Link컴포넌트처럼 사용하고, to={라우팅 경로} 로 수정해서 csr로 동작하게 수정

+ 1.1 로그인은 새로고침해도 초기화 되면 안되니까 recoil persist 라이브러리 사용해서 localStorage에 저장하는 걸 권장함

2. login input 이벤트 발생시 그냥 state onchange걸어줘서 한 글자 입력시 re-render
useRef써서 수정함
